### PR TITLE
Make filters parameter optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickandmortar/kibana-url-builder",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Kibana URL builder",
   "scripts": {
     "build": "tsc",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,7 +7,7 @@ const defaultPeriod: types.KibanaQueryPeriod = {
   to: 'now'
 }
 
-export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filters, index, interval, query, sort }: types.KibanaDiscoverUrlBuildParameters): string {
+export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filters = [], index, interval, query, sort }: types.KibanaDiscoverUrlBuildParameters): string {
   if (!columns || columns.length === 0) {
     columns = ['_source']
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface KibanaDiscoverUrlBuildParameters {
   refreshInterval?: KibanaQueryRefreshInterval;
   period?: KibanaQueryPeriod;
   columns?: string[];
-  filters: KibanaQueryFilter[];
+  filters?: KibanaQueryFilter[];
   index?: string;
   interval?: string;
   query?: string;

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -9,4 +9,14 @@ describe('buildDiscoverUrl', function () {
 
     expect(url).toBe("http://kibana/app/kibana#/discover?_g=(time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(),interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))")
   })
+
+  it('should add a default value for filters when none is not provided', function () {
+    const url = buildDiscoverUrl({
+      host: 'http://kibana',
+    })
+
+    expect(url).toBe(
+      "http://kibana/app/kibana#/discover?_g=(time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(),interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))"
+    );
+  })
 })


### PR DESCRIPTION
_First of all, thank you for this module, it avoided us rewriting a custom Kibana url builder_ 🙏 

# Context
While looking at the documentation, it says that `filters` parameter is optional and its default value is `[]`. It was not the case

# Changes
- add `node_modules` to `.gitignore`
- make `filters` optional