### PR TITLE
Do not set a default value to columns parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This method returns a stateless Kibana "Discover" URL, which can be shared and u
 | Parameter | Type | Default | Required | Example |
 |---|---|---|---|---|
 | `host` | `string` | | ✅ | `http://kibana:5601` |
-| `columns` | `string[]` | `['_source']` | | `['_source', 'log']` |
+| `columns` | `string[]` | | | `['_source', 'log']` |
 | `filters` | `KibanaQueryFilter[]` | `[]` | | See below |
 | `query` | `string` | | | `foo AND bar` (Lucene syntax) |
 | `period` | `KibanaQueryPeriod` | `{ "from": "now-15m", "mode": "quick", "to": "now" }` | | See below |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickandmortar/kibana-url-builder",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Kibana URL builder",
   "scripts": {
     "build": "tsc",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -8,10 +8,6 @@ const defaultPeriod: types.KibanaQueryPeriod = {
 }
 
 export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filters, index, interval, query, sort }: types.KibanaDiscoverUrlBuildParameters): string {
-  if (!columns || columns.length === 0) {
-    columns = ['_source']
-  }
-
   const queryFilters = []
 
   filters.forEach((filter) => {
@@ -109,10 +105,14 @@ export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filt
     _g.refreshInterval = refreshInterval
   }
 
-  const _a: any = { columns, interval, filters: queryFilters, sort: [sort.field, sort.direction] }
+  const _a: any = { interval, filters: queryFilters, sort: [sort.field, sort.direction] }
 
   if (index) {
     _a.index = index
+  }
+
+  if (columns) {
+    _a.columns = columns
   }
 
   _a.query = {

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -3,10 +3,20 @@ import { buildDiscoverUrl } from '../src'
 describe('buildDiscoverUrl', function () {
   it('default', function () {
     const url = buildDiscoverUrl({
+      columns: ['_source'],
       host: 'http://kibana',
       filters: []
     })
 
     expect(url).toBe("http://kibana/app/kibana#/discover?_g=(time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(),interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))")
+  })
+
+  it('should not add columns parameter if none is provider', function () {
+    const url = buildDiscoverUrl({
+      host: 'http://kibana',
+      filters: []
+    })
+
+    expect(url).toBe("http://kibana/app/kibana#/discover?_g=(time:(from:now-15m,mode:quick,to:now))&_a=(filters:!(),interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))")
   })
 })


### PR DESCRIPTION
# Context
Currently, when no `columns` parameters is set, it defaults to `[_source]`. This conflicts with the default columns set in Kibana itself. Letting it empty will allow Kibana to use the default columns set in its configuration.

This change might be a bit opinionated, let me know if you disagree with it

# Changes
- add `node_modules` to `.gitignore`
- do not add `columns` parameter if none is passed