### PR TITLE
Add language parameter to select query language used by Kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ This method returns a stateless Kibana "Discover" URL, which can be shared and u
 | `host` | `string` | | ✅ | `http://kibana:5601` |
 | `columns` | `string[]` | `['_source']` | | `['_source', 'log']` |
 | `filters` | `KibanaQueryFilter[]` | `[]` | | See below |
-| `query` | `string` | | | `foo AND bar` (Lucene syntax) |
+| `query` | `string` | | | `foo AND bar` (syntax of the selected `language`) |
 | `period` | `KibanaQueryPeriod` | `{ "from": "now-15m", "mode": "quick", "to": "now" }` | | See below |
 | `index` | `string` | | When using filters | `my-index-pattern` |
 | `interval` | `string` | `auto` | | `15m` |
 | `refreshInterval` | `KibanaQueryRefreshInterval` | `{ "pause": true, "value": 300000 }` | | |
 | `sort` | `KibanaQuerySort` | `{ "field": "@timestamp", "direction": "desc" }` | | |
+| `language` | `KibanaQueryLanguage` | `lucene` | | `kuery` |
 
 #### Filters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickandmortar/kibana-url-builder",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Kibana URL builder",
   "scripts": {
     "build": "tsc",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,7 +7,7 @@ const defaultPeriod: types.KibanaQueryPeriod = {
   to: 'now'
 }
 
-export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filters, index, interval, query, sort }: types.KibanaDiscoverUrlBuildParameters): string {
+export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filters, index, interval, query, sort, language = 'lucene' }: types.KibanaDiscoverUrlBuildParameters): string {
   if (!columns || columns.length === 0) {
     columns = ['_source']
   }
@@ -116,7 +116,7 @@ export function buildDiscoverUrl ({ host, refreshInterval, period, columns, filt
   }
 
   _a.query = {
-    language: 'lucene',
+    language,
     query: query ?? ''
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface KibanaQuerySort {
   direction: 'desc' | 'asc';
 }
 
+type KibanaQueryLanguage = 'lucene' | 'kuery';
+
 export interface KibanaDiscoverUrlBuildParameters {
   host: string;
   refreshInterval?: KibanaQueryRefreshInterval;
@@ -33,4 +35,5 @@ export interface KibanaDiscoverUrlBuildParameters {
   interval?: string;
   query?: string;
   sort?: KibanaQuerySort;
+  language?: KibanaQueryLanguage;
 }


### PR DESCRIPTION
# Context
By default it uses `lucene` query language but there is now a new query language supported by Kibana, [`kuery`](https://www.elastic.co/guide/en/kibana/current/kuery-query.html)

# Changes
- add `node_modules` to `.gitignore`
- allow to pass a `language` parameter defaulting to `lucene`